### PR TITLE
Closes #98; Hash ids are associated with the top of their content

### DIFF
--- a/css/convictions.css
+++ b/css/convictions.css
@@ -14,12 +14,12 @@ body {
   position: relative;
 }
 
-/* Associate hash ids with closer 
+/* Associate seciton ids with closer 
    to their actual location. */
-[id]:before { 
+section[id]:before { 
   display: block; 
-  margin-top: -60px; 
-  height: 60px; 
+  margin-top: -85px; 
+  height: 85px; 
   visibility: hidden; 
 }
 


### PR DESCRIPTION
Not only does this make navigating via hash work better, it makes the `scrollspy` listener for hash ids detect section changes at more appropriate times.
